### PR TITLE
新增支持自定义endpoint的方法，完善grafana图标上单位和label的一些展示

### DIFF
--- a/ginprom-service.json
+++ b/ginprom-service.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 242,
-  "iteration": 1608113839785,
+  "iteration": 1608172494931,
   "links": [],
   "panels": [
     {
@@ -658,9 +658,8 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "text": "mserver-sandbox",
-          "value": "mserver-sandbox"
+          "text": "",
+          "value": ""
         },
         "datasource": "$datasource",
         "definition": "label_values(service_http_request_count_total, job)",
@@ -684,9 +683,8 @@
       },
       {
         "current": {
-          "selected": true,
-          "text": "beijing-prod",
-          "value": "beijing-prod"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 2,
         "includeAll": false,
@@ -705,7 +703,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "1m",
           "value": "1m"
         },
@@ -772,7 +770,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -799,9 +797,8 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "text": "GET",
+          "value": "GET"
         },
         "datasource": "$datasource",
         "definition": "label_values(service_http_request_count_total, method)",
@@ -826,9 +823,8 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "text": "200",
+          "value": "200"
         },
         "datasource": "$datasource",
         "definition": "label_values(service_http_request_count_total, status)",
@@ -853,7 +849,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "tags": [],
           "text": "0.95",
           "value": "0.95"
         },

--- a/ginprom-service.json
+++ b/ginprom-service.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 7,
-  "iteration": 1569654029911,
+  "id": 242,
+  "iteration": 1608113839785,
   "links": [],
   "panels": [
     {
@@ -60,7 +60,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -110,12 +109,14 @@
       "datasource": "$datasource",
       "decimals": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 12,
         "w": 18,
         "x": 6,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "alignAsTable": true,
@@ -132,7 +133,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -145,8 +148,9 @@
         {
           "expr": "rate(service_http_request_count_total{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ endpoint }}",
+          "legendFormat": "{{ endpoint }}-{{method}}-{{status}}",
           "refId": "A"
         }
       ],
@@ -232,7 +236,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "pluginVersion": "6.2.1",
       "postfix": "",
       "postfixFontSize": "50%",
@@ -282,12 +285,14 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 11,
         "w": 12,
         "x": 0,
         "y": 12
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "alignAsTable": true,
@@ -303,7 +308,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -316,8 +323,9 @@
         {
           "expr": "rate(service_http_request_size_bytes_sum{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])\n/\nrate(service_http_request_size_bytes_count{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ endpoint }}",
+          "legendFormat": "{{ endpoint }}-{{method}}-{{status}}",
           "refId": "A"
         }
       ],
@@ -341,7 +349,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -369,12 +377,14 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 11,
         "w": 12,
         "x": 12,
         "y": 12
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "alignAsTable": true,
@@ -390,7 +400,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -403,8 +415,9 @@
         {
           "expr": "rate(service_http_request_duration_seconds_sum{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])\r\n/\r\nrate(service_http_request_duration_seconds_count{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ endpoint }}",
+          "legendFormat": "{{ endpoint }}-{{method}}-{{status}}",
           "refId": "A"
         }
       ],
@@ -428,7 +441,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -456,12 +469,14 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 12,
         "w": 12,
         "x": 0,
         "y": 23
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": true,
@@ -476,7 +491,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -489,6 +506,7 @@
         {
           "expr": "histogram_quantile($quantile, sum(rate(service_http_request_duration_seconds_bucket{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])) by (le))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{ endpoint }}",
           "refId": "A"
@@ -514,7 +532,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -543,12 +561,14 @@
       "datasource": "$datasource",
       "description": "",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 12,
         "w": 12,
         "x": 12,
         "y": 23
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "alignAsTable": true,
@@ -564,7 +584,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -577,8 +599,9 @@
         {
           "expr": "rate(service_http_response_size_bytes_sum{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])\n/\nrate(service_http_response_size_bytes_count{job=~\"$job\", endpoint=~\"$endpoint\", method=~\"$method\", status=~\"$status\"}[$interval])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ endpoint }}",
+          "legendFormat": "{{ endpoint }}-{{method}}-{{status}}",
           "refId": "A"
         }
       ],
@@ -602,7 +625,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -625,7 +648,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [
     "Service"
@@ -635,13 +658,15 @@
       {
         "allValue": null,
         "current": {
-          "text": "",
-          "value": ""
+          "selected": true,
+          "text": "mserver-sandbox",
+          "value": "mserver-sandbox"
         },
         "datasource": "$datasource",
         "definition": "label_values(service_http_request_count_total, job)",
         "hide": 0,
         "includeAll": false,
+        "index": -1,
         "label": "Job",
         "multi": false,
         "name": "job",
@@ -659,8 +684,9 @@
       },
       {
         "current": {
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "selected": true,
+          "text": "beijing-prod",
+          "value": "beijing-prod"
         },
         "hide": 2,
         "includeAll": false,
@@ -679,6 +705,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
+          "selected": true,
           "text": "1m",
           "value": "1m"
         },
@@ -745,6 +772,7 @@
       {
         "allValue": null,
         "current": {
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
@@ -752,6 +780,7 @@
         "definition": "label_values(service_http_request_count_total{endpoint!~\"/metrics\", status!=\"404\", job=~\"$job\"}, endpoint)",
         "hide": 0,
         "includeAll": true,
+        "index": -1,
         "label": "Endpoint",
         "multi": false,
         "name": "endpoint",
@@ -770,13 +799,15 @@
       {
         "allValue": null,
         "current": {
-          "text": "GET",
-          "value": "GET"
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "$datasource",
         "definition": "label_values(service_http_request_count_total, method)",
         "hide": 0,
         "includeAll": true,
+        "index": -1,
         "label": "Method",
         "multi": false,
         "name": "method",
@@ -795,13 +826,15 @@
       {
         "allValue": null,
         "current": {
-          "text": "200",
-          "value": "200"
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "$datasource",
         "definition": "label_values(service_http_request_count_total, status)",
         "hide": 0,
         "includeAll": true,
+        "index": -1,
         "label": "Status",
         "multi": false,
         "name": "status",
@@ -820,7 +853,7 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
+          "selected": true,
           "text": "0.95",
           "value": "0.95"
         },
@@ -883,5 +916,8 @@
   "timezone": "browser",
   "title": "Prometheus Service",
   "uid": "EyaoypOZz",
-  "version": 18
+  "variables": {
+    "list": []
+  },
+  "version": 9
 }

--- a/middleware.go
+++ b/middleware.go
@@ -135,7 +135,8 @@ func PromMiddleware(promOpts *PromOpts) gin.HandlerFunc {
 	if promOpts == nil {
 		promOpts = NewDefaultOpts()
 	}
-	// suport older usage way
+
+	// make sure EndpointLabelMappingFn is callable
 	if promOpts.EndpointLabelMappingFn == nil {
 		promOpts.EndpointLabelMappingFn = func(c *gin.Context) string {
 			return c.Request.URL.Path
@@ -177,4 +178,3 @@ func PromHandler(handler http.Handler) gin.HandlerFunc {
 		handler.ServeHTTP(c.Writer, c.Request)
 	}
 }
-


### PR DESCRIPTION
类似https://github.com/zsais/go-gin-prometheus
可以满足[/customer/:name] 这种类型的自定义endpoint label